### PR TITLE
epic: 국내야구, 롤 크롤링

### DIFF
--- a/src/main/java/com/playhive/batch/crawler/FootballBaseballCrawler.java
+++ b/src/main/java/com/playhive/batch/crawler/FootballBaseballCrawler.java
@@ -1,0 +1,99 @@
+package com.playhive.batch.crawler;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import com.playhive.batch.news.dto.NewsSaveRequest;
+import com.playhive.batch.news.service.NewsService;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public abstract class FootballBaseballCrawler {
+
+	private static final String DATE_FIELD = "&date";
+	private static final String EQUALS = "=";
+	private static final String PAGE_FIELD = "&page";
+
+	private static final String NEWS_LIST_CLASS = "news_list";
+	private static final String TIME_CLASS = "time";
+	private static final String TITLE_CLASS = "text";
+	private static final String THUMB_CLASS = "thmb";
+	private static final String PAGE_CLASS = "paginate";
+
+	private static final String LI_TAG = "li";
+	private static final String SPAN_TAG = "span";
+	private static final String IMG_TAG = "img";
+	private static final String SRC_ATTR = "src";
+	private static final String A_TAG = "a";
+
+	private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+	private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm");
+
+	private final WebDriver webDriver;
+	private final NewsService newsService;
+
+	protected void crawlForDate(String url, LocalDate date, boolean yesterday) {
+		IntStream.rangeClosed(1, getPaginationCount(url, date)).forEach(pageCount -> {
+			webDriver.get(url + DATE_FIELD + EQUALS + date.format(FORMATTER) + PAGE_FIELD + EQUALS + pageCount);
+			saveNews(yesterday);
+		});
+	}
+
+	private void saveNews(boolean yesterday) {
+		for (WebElement news : getNewsList()) {
+			String postDate = getPostDate(news);
+			LocalDateTime newsPostDate = LocalDateTime.parse(postDate, TIME_FORMATTER);
+			// 오전 6시 크롤링이기 때문에 전날 뉴스는 오전 6시이후로만 가져오도록
+			if (yesterday && newsPostDate.toLocalTime().isBefore(LocalTime.of(6, 0))) {
+				break;
+			}
+			saveNews(getTitle(news), getThumbImg(news), newsPostDate);
+		}
+	}
+
+	private void saveNews(String title, String thumbImg, LocalDateTime postDate) {
+		this.newsService.saveNews(NewsSaveRequest.createFootballRequest(title, thumbImg, postDate));
+	}
+
+	private List<WebElement> getNewsList() {
+		WebElement newsListElement = webDriver.findElement(By.className(NEWS_LIST_CLASS));
+		return newsListElement.findElements(By.tagName(LI_TAG));
+	}
+
+	//뉴스 시간가져오기
+	private String getPostDate(WebElement news) {
+		return news.findElement(By.className(TIME_CLASS)).getText();
+	}
+
+	//뉴스 타이틀가져오기
+	private String getTitle(WebElement news) {
+		return news.findElement(By.className(TITLE_CLASS)).findElement(By.tagName(SPAN_TAG)).getText();
+	}
+
+	//썸네일 이미지 가져오기, 없으면 null
+	private String getThumbImg(WebElement news) {
+		try {
+			return news.findElement(By.className(THUMB_CLASS)).findElement(By.tagName(IMG_TAG)).getAttribute(SRC_ATTR);
+		} catch (NoSuchElementException e) {
+			return null;
+		}
+	}
+
+	//페이징 개수 가져오기
+	private int getPaginationCount(String url, LocalDate date) {
+		webDriver.get(url + DATE_FIELD + EQUALS + date.format(FORMATTER) + PAGE_FIELD + EQUALS + 1);
+		WebElement paginationElement = webDriver.findElement(By.className(PAGE_CLASS));
+		List<WebElement> pageLinks = paginationElement.findElements(By.tagName(A_TAG));
+		return pageLinks.size();
+	}
+}

--- a/src/main/java/com/playhive/batch/crawler/FootballBaseballCrawler.java
+++ b/src/main/java/com/playhive/batch/crawler/FootballBaseballCrawler.java
@@ -42,19 +42,19 @@ public abstract class FootballBaseballCrawler {
 	private final WebDriver webDriver;
 	private final NewsService newsService;
 
-	protected void crawlForDate(String url, LocalDate date, boolean yesterday) {
+	protected void crawlForDate(String url, LocalDate date, boolean isYesterday) {
 		IntStream.rangeClosed(1, getPaginationCount(url, date)).forEach(pageCount -> {
 			webDriver.get(url + DATE_FIELD + EQUALS + date.format(FORMATTER) + PAGE_FIELD + EQUALS + pageCount);
-			saveNews(yesterday);
+			saveNews(isYesterday);
 		});
 	}
 
-	private void saveNews(boolean yesterday) {
+	private void saveNews(boolean isYesterday) {
 		for (WebElement news : getNewsList()) {
 			String postDate = getPostDate(news);
 			LocalDateTime newsPostDate = LocalDateTime.parse(postDate, TIME_FORMATTER);
 			// 오전 6시 크롤링이기 때문에 전날 뉴스는 오전 6시이후로만 가져오도록
-			if (yesterday && newsPostDate.toLocalTime().isBefore(LocalTime.of(6, 0))) {
+			if (isYesterday && newsPostDate.toLocalTime().isBefore(LocalTime.of(6, 0))) {
 				break;
 			}
 			saveNews(getTitle(news), getThumbImg(news), newsPostDate);

--- a/src/main/java/com/playhive/batch/crawler/baseball/BaseballNewsCrawler.java
+++ b/src/main/java/com/playhive/batch/crawler/baseball/BaseballNewsCrawler.java
@@ -14,99 +14,25 @@ import org.openqa.selenium.WebElement;
 import org.springframework.stereotype.Component;
 
 import com.playhive.batch.crawler.Crawler;
+import com.playhive.batch.crawler.FootballBaseballCrawler;
 import com.playhive.batch.news.dto.NewsSaveRequest;
 import com.playhive.batch.news.service.NewsService;
 
 import lombok.RequiredArgsConstructor;
 
 @Component
-@RequiredArgsConstructor
-public class BaseballNewsCrawler implements Crawler {
+public class BaseballNewsCrawler extends FootballBaseballCrawler implements Crawler {
 
 	private static final String URL = "https://sports.news.naver.com/kbaseball/news/index?isphoto=N";
 
-	private static final String DATE_FIELD = "&date";
-	private static final String EQUALS = "=";
-	private static final String PAGE_FIELD = "&page";
-
-	private static final String NEWS_LIST_CLASS = "news_list";
-	private static final String TIME_CLASS = "time";
-	private static final String TITLE_CLASS = "text";
-	private static final String THUMB_CLASS = "thmb";
-	private static final String PAGE_CLASS = "paginate";
-
-	private static final String LI_TAG = "li";
-	private static final String SPAN_TAG = "span";
-	private static final String IMG_TAG = "img";
-	private static final String SRC_ATTR = "src";
-	private static final String A_TAG = "a";
-
-	private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
-	private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm");
-
-	private final WebDriver webDriver;
-	private final NewsService newsService;
+	public BaseballNewsCrawler(WebDriver webDriver, NewsService newsService) {
+		super(webDriver, newsService);
+	}
 
 	@Override
 	public void crawl() {
 		LocalDate currentDate = LocalDate.now();
-		crawlForDate(currentDate.minusDays(1), true); // 어제 뉴스 크롤링
-		crawlForDate(currentDate, false); // 오늘 뉴스 크롤링
-	}
-
-	private void crawlForDate(LocalDate date, boolean yesterday) {
-		IntStream.rangeClosed(1, getPaginationCount(date)).forEach(pageCount -> {
-			webDriver.get(URL + DATE_FIELD + EQUALS + date.format(FORMATTER) + PAGE_FIELD + EQUALS + pageCount);
-			saveNews(yesterday);
-		});
-	}
-
-	private void saveNews(boolean yesterday) {
-		for (WebElement news : getNewsList()) {
-			String postDate = getPostDate(news);
-			LocalDateTime newsPostDate = LocalDateTime.parse(postDate, TIME_FORMATTER);
-			// 오전 6시 크롤링이기 때문에 전날 뉴스는 오전 6시이후로만 가져오도록
-			if (yesterday && newsPostDate.toLocalTime().isBefore(LocalTime.of(6, 0))) {
-				break;
-			}
-
-			saveNews(getTitle(news), getThumbImg(news), newsPostDate);
-		}
-	}
-
-	private void saveNews(String title, String thumbImg, LocalDateTime postDate) {
-		this.newsService.saveNews(NewsSaveRequest.createBaseballRequest(title, thumbImg, postDate));
-	}
-
-	private List<WebElement> getNewsList() {
-		WebElement newsListElement = webDriver.findElement(By.className(NEWS_LIST_CLASS));
-		return newsListElement.findElements(By.tagName(LI_TAG));
-	}
-
-	//뉴스 시간가져오기
-	private String getPostDate(WebElement news) {
-		return news.findElement(By.className(TIME_CLASS)).getText();
-	}
-
-	//뉴스 타이틀가져오기
-	private String getTitle(WebElement news) {
-		return news.findElement(By.className(TITLE_CLASS)).findElement(By.tagName(SPAN_TAG)).getText();
-	}
-
-	//썸네일 이미지 가져오기, 없으면 null
-	private String getThumbImg(WebElement news) {
-		try {
-			return news.findElement(By.className(THUMB_CLASS)).findElement(By.tagName(IMG_TAG)).getAttribute(SRC_ATTR);
-		} catch (NoSuchElementException e) {
-			return null;
-		}
-	}
-
-	//페이징 개수 가져오기
-	private int getPaginationCount(LocalDate date) {
-		webDriver.get(URL + DATE_FIELD + EQUALS + date.format(FORMATTER) + PAGE_FIELD + EQUALS + 1);
-		WebElement paginationElement = webDriver.findElement(By.className(PAGE_CLASS));
-		List<WebElement> pageLinks = paginationElement.findElements(By.tagName(A_TAG));
-		return pageLinks.size();
+		crawlForDate(URL, currentDate.minusDays(1), true); // 어제 뉴스 크롤링
+		crawlForDate(URL, currentDate, false); // 오늘 뉴스 크롤링
 	}
 }

--- a/src/main/java/com/playhive/batch/crawler/baseball/BaseballNewsCrawler.java
+++ b/src/main/java/com/playhive/batch/crawler/baseball/BaseballNewsCrawler.java
@@ -1,4 +1,4 @@
-package com.playhive.batch.crawler.football;
+package com.playhive.batch.crawler.baseball;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -21,9 +21,9 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class FootballNewsCrawler implements Crawler {
+public class BaseballNewsCrawler implements Crawler {
 
-	private static final String URL = "https://sports.news.naver.com/wfootball/news/index?isphoto=N";
+	private static final String URL = "https://sports.news.naver.com/kbaseball/news/index?isphoto=N";
 
 	private static final String DATE_FIELD = "&date";
 	private static final String EQUALS = "=";
@@ -75,7 +75,7 @@ public class FootballNewsCrawler implements Crawler {
 	}
 
 	private void saveNews(String title, String thumbImg, LocalDateTime postDate) {
-		this.newsService.saveNews(NewsSaveRequest.createFootballRequest(title, thumbImg, postDate));
+		this.newsService.saveNews(NewsSaveRequest.createBaseballRequest(title, thumbImg, postDate));
 	}
 
 	private List<WebElement> getNewsList() {

--- a/src/main/java/com/playhive/batch/crawler/esports/EsportsNewsCrawler.java
+++ b/src/main/java/com/playhive/batch/crawler/esports/EsportsNewsCrawler.java
@@ -57,19 +57,19 @@ public class EsportsNewsCrawler implements Crawler {
 		crawlForDate(currentDate, false); // 오늘 뉴스 크롤링
 	}
 
-	private void crawlForDate(LocalDate date, boolean yesterday) {
+	private void crawlForDate(LocalDate date, boolean isYesterday) {
 		webDriver.get(URL + DATE_FIELD + EQUALS + date);
 
 		//ESports기사는 직접 URL에 날짜 입력해서 접근 시 당일날짜로 redirect되는 이슈가 있어 이전날짜는 직접 클릭해서 넘어가는걸로
-		clickDateBtn(yesterday, date);
+		clickDateBtn(isYesterday, date);
 
 		//뉴스 더보기 클릭으로 페이징이 되어있어 클릭이 안될 때까지 클릭하여 전체기사 가져오기
 		clickLoadNews();
-		saveNews(yesterday);
+		saveNews(isYesterday);
 	}
 
-	private void clickDateBtn(boolean yesterday, LocalDate date) {
-		if (yesterday) {
+	private void clickDateBtn(boolean isYesterday, LocalDate date) {
+		if (isYesterday) {
 			String dateLinkText = date.format(DateTimeFormatter.ofPattern(DATE_BTN_PATTERN));
 			webDriver.findElement(By.linkText(dateLinkText)).click();
 		}
@@ -87,7 +87,7 @@ public class EsportsNewsCrawler implements Crawler {
 		}
 	}
 
-	private void saveNews(boolean yesterday) {
+	private void saveNews(boolean isYesterday) {
 		for (WebElement news : getNewsList()) {
 			String postDate = getPostDate(news);
 			//뉴스계시날짜가 없으면 기사가 없는것
@@ -96,10 +96,9 @@ public class EsportsNewsCrawler implements Crawler {
 			}
 			LocalDateTime newsPostDate = parseRelativeTime(postDate);
 			// 오전 6시 크롤링이기 때문에 전날 뉴스는 오전 6시이후로만 가져오도록
-			if (yesterday && newsPostDate.toLocalTime().isBefore(LocalTime.of(6, 0))) {
+			if (isYesterday && newsPostDate.toLocalTime().isBefore(LocalTime.of(6, 0))) {
 				break;
 			}
-
 			saveNews(getTitle(news), getThumbImg(news, newsPostDate), newsPostDate);
 		}
 	}

--- a/src/main/java/com/playhive/batch/crawler/esports/EsportsNewsCrawler.java
+++ b/src/main/java/com/playhive/batch/crawler/esports/EsportsNewsCrawler.java
@@ -1,0 +1,159 @@
+package com.playhive.batch.crawler.esports;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.springframework.stereotype.Component;
+
+import com.playhive.batch.crawler.Crawler;
+import com.playhive.batch.news.dto.NewsSaveRequest;
+import com.playhive.batch.news.service.NewsService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class EsportsNewsCrawler implements Crawler {
+
+	private static final String URL = "https://game.naver.com/esports/League_of_Legends/news/lol";
+
+	private static final String DATE_FIELD = "?date";
+	private static final String EQUALS = "=";
+
+	private static final String NEWS_LIST_CLASS = "news_list_container__1L7tH";
+
+	private static final String TIME_CLASS = "news_card_source__1jv12";
+	private static final String TITLE_CLASS = "news_card_title__1fVVk";
+	private static final String LOAD_NEWS_CLASS = "news_list_more_btn__3QwSl";
+
+	private static final String LI_TAG = "li.news_card_item__2lh4o";
+	private static final String SVG_TAG = "svg";
+
+	private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm");
+
+	private static final String TIME_PATTERN = "(\\d+)\\s*(분|시간)\\s*전";
+	private static final String DATE_BTN_PATTERN = "MM.dd(EEE)";
+
+	private static final String MINUTE_KOREAN = "분";
+	private static final String HOUR_KOREAN = "시간";
+
+	private final WebDriver webDriver;
+	private final NewsService newsService;
+
+	@Override
+	public void crawl() {
+		LocalDate currentDate = LocalDate.now();
+		crawlForDate(currentDate.minusDays(1), true); // 어제 뉴스 크롤링
+		crawlForDate(currentDate, false); // 오늘 뉴스 크롤링
+	}
+
+	private void crawlForDate(LocalDate date, boolean yesterday) {
+		webDriver.get(URL + DATE_FIELD + EQUALS + date);
+
+		//ESports기사는 직접 URL에 날짜 입력해서 접근 시 당일날짜로 redirect되는 이슈가 있어 이전날짜는 직접 클릭해서 넘어가는걸로
+		clickDateBtn(yesterday, date);
+
+		//뉴스 더보기 클릭으로 페이징이 되어있어 클릭이 안될 때까지 클릭하여 전체기사 가져오기
+		clickLoadNews();
+		saveNews(yesterday);
+	}
+
+	private void clickDateBtn(boolean yesterday, LocalDate date) {
+		if (yesterday) {
+			String dateLinkText = date.format(DateTimeFormatter.ofPattern(DATE_BTN_PATTERN));
+			webDriver.findElement(By.linkText(dateLinkText)).click();
+		}
+	}
+
+	private void clickLoadNews() {
+		while (true) {
+			try {
+				// 뉴스 더보기 버튼을 찾고 클릭
+				WebElement loadMoreButton = webDriver.findElement(By.className(LOAD_NEWS_CLASS));
+				loadMoreButton.click();
+			} catch (NoSuchElementException | StaleElementReferenceException e) { // 뉴스 더보기 버튼이 없거만 클릭이 안되면 종료
+				break;
+			}
+		}
+	}
+
+	private void saveNews(boolean yesterday) {
+		for (WebElement news : getNewsList()) {
+			String postDate = getPostDate(news);
+			//뉴스계시날짜가 없으면 기사가 없는것
+			if (postDate == null) {
+				break;
+			}
+			LocalDateTime newsPostDate = parseRelativeTime(postDate);
+			// 오전 6시 크롤링이기 때문에 전날 뉴스는 오전 6시이후로만 가져오도록
+			if (yesterday && newsPostDate.toLocalTime().isBefore(LocalTime.of(6, 0))) {
+				break;
+			}
+
+			saveNews(getTitle(news), getThumbImg(news, newsPostDate), newsPostDate);
+		}
+	}
+
+	private void saveNews(String title, String thumbImg, LocalDateTime postDate) {
+		this.newsService.saveNews(NewsSaveRequest.createEsportsRequest(title, thumbImg, postDate));
+	}
+
+	private List<WebElement> getNewsList() {
+		WebElement newsListElement = webDriver.findElement(By.className(NEWS_LIST_CLASS));
+		return newsListElement.findElements(By.cssSelector(LI_TAG));
+	}
+
+	//뉴스 시간가져오기
+	private String getPostDate(WebElement news) {
+		List<WebElement> timeElements = news.findElements(By.className(TIME_CLASS));
+		WebElement firstTimeElement = timeElements.get(1);
+		// SVG 존재 여부 확인 존재하면 당일 기사가 없어서 인기순으로 redirect된 상황
+		try {
+			firstTimeElement.findElement(By.tagName(SVG_TAG));
+			return null;
+		} catch (NoSuchElementException e) {
+			return firstTimeElement.getText();
+		}
+	}
+
+	//뉴스 타이틀가져오기
+	private String getTitle(WebElement news) {
+		return news.findElement(By.className(TITLE_CLASS)).getText();
+	}
+
+	//뉴스썸네일 만들기, ESports는 해외축구, 국내야구와 다르게 다른 뉴스페이지인데 썸네일을 가져올 수가 없어 조합하여 사용
+	private String getThumbImg(WebElement news, LocalDateTime newsPostDate) {
+		ThumbImg thumbImg = new ThumbImg();
+		thumbImg.createThumbImgUrl(news, newsPostDate);
+		return thumbImg.getUrl();
+	}
+
+	//ESports는 해외축구, 국내야구와 다르게 24시간까지는 날짜가 아니라 *분전, *시간전으로 표기되어 자세한 뉴스 날짜를 알수가 없어 현재 시간 기준으로 계산
+	private LocalDateTime parseRelativeTime(String relativeTime) {
+		Pattern pattern = Pattern.compile(TIME_PATTERN);
+		Matcher matcher = pattern.matcher(relativeTime);
+		if (matcher.find()) {
+			return checkUnit(Integer.parseInt(matcher.group(1)), matcher.group(2));
+		}
+		return LocalDateTime.parse(relativeTime, TIME_FORMATTER);
+	}
+
+	private LocalDateTime checkUnit(int amount, String unit) {
+		LocalDateTime now = LocalDateTime.now();
+		return switch (unit) {
+			case MINUTE_KOREAN -> now.minusMinutes(amount);
+			case HOUR_KOREAN -> now.minusHours(amount);
+			default -> throw new IllegalArgumentException("알 수 없는 시간 단위: " + unit);
+		};
+	}
+}

--- a/src/main/java/com/playhive/batch/crawler/esports/ThumbImg.java
+++ b/src/main/java/com/playhive/batch/crawler/esports/ThumbImg.java
@@ -1,0 +1,64 @@
+package com.playhive.batch.crawler.esports;
+
+import java.time.LocalDateTime;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class ThumbImg {
+	private static final String URL = "https://imgnews.pstatic.net/image/origin/%s/%s/%s/%s/%s.jpg?type=nf472_236";
+	private static final String HREF_URL_PATTURN = "https://m\\.sports\\.naver\\.com/esports/article/(\\d{3})/(\\d+)";
+
+	private String category;
+	private String year;
+	private String month;
+	private String day;
+	private String articleId;
+
+	@Builder
+	public ThumbImg(String category, String year, String month, String day, String articleId) {
+		this.category = category;
+		this.year = year;
+		this.month = month;
+		this.day = day;
+		this.articleId = articleId;
+	}
+
+	public void createThumbImgUrl(WebElement news, LocalDateTime newsPostDate) {
+		updateCategoryArticleId(news);
+		updateDate(newsPostDate);
+	}
+
+	public String getUrl() {
+		return String.format(URL,
+			this.category,
+			this.year,
+			this.month,
+			this.day,
+			this.articleId.replaceFirst("^0+", ""));
+	}
+
+	private void updateCategoryArticleId(WebElement news) {
+		String linkUrl = news.findElement(By.tagName("a")).getAttribute("href");
+
+		Pattern pattern = Pattern.compile(HREF_URL_PATTURN);
+		Matcher matcher = pattern.matcher(linkUrl);
+
+		if (matcher.find()) {
+			this.category = matcher.group(1);
+			this.articleId = matcher.group(2);
+		}
+	}
+
+	private void updateDate(LocalDateTime newsPostDate) {
+		this.year = String.valueOf(newsPostDate.getYear());
+		this.month = String.format("%02d", newsPostDate.getMonthValue());
+		this.day = String.format("%02d", newsPostDate.getDayOfMonth());
+	}
+}

--- a/src/main/java/com/playhive/batch/crawler/football/FootballNewsCrawler.java
+++ b/src/main/java/com/playhive/batch/crawler/football/FootballNewsCrawler.java
@@ -14,99 +14,25 @@ import org.openqa.selenium.WebElement;
 import org.springframework.stereotype.Component;
 
 import com.playhive.batch.crawler.Crawler;
+import com.playhive.batch.crawler.FootballBaseballCrawler;
 import com.playhive.batch.news.dto.NewsSaveRequest;
 import com.playhive.batch.news.service.NewsService;
 
 import lombok.RequiredArgsConstructor;
 
 @Component
-@RequiredArgsConstructor
-public class FootballNewsCrawler implements Crawler {
+public class FootballNewsCrawler extends FootballBaseballCrawler implements Crawler {
 
 	private static final String URL = "https://sports.news.naver.com/wfootball/news/index?isphoto=N";
 
-	private static final String DATE_FIELD = "&date";
-	private static final String EQUALS = "=";
-	private static final String PAGE_FIELD = "&page";
-
-	private static final String NEWS_LIST_CLASS = "news_list";
-	private static final String TIME_CLASS = "time";
-	private static final String TITLE_CLASS = "text";
-	private static final String THUMB_CLASS = "thmb";
-	private static final String PAGE_CLASS = "paginate";
-
-	private static final String LI_TAG = "li";
-	private static final String SPAN_TAG = "span";
-	private static final String IMG_TAG = "img";
-	private static final String SRC_ATTR = "src";
-	private static final String A_TAG = "a";
-
-	private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
-	private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm");
-
-	private final WebDriver webDriver;
-	private final NewsService newsService;
+	public FootballNewsCrawler(WebDriver webDriver, NewsService newsService) {
+		super(webDriver, newsService);
+	}
 
 	@Override
 	public void crawl() {
 		LocalDate currentDate = LocalDate.now();
-		crawlForDate(currentDate.minusDays(1), true); // 어제 뉴스 크롤링
-		crawlForDate(currentDate, false); // 오늘 뉴스 크롤링
-	}
-
-	private void crawlForDate(LocalDate date, boolean yesterday) {
-		IntStream.rangeClosed(1, getPaginationCount(date)).forEach(pageCount -> {
-			webDriver.get(URL + DATE_FIELD + EQUALS + date.format(FORMATTER) + PAGE_FIELD + EQUALS + pageCount);
-			saveNews(yesterday);
-		});
-	}
-
-	private void saveNews(boolean yesterday) {
-		for (WebElement news : getNewsList()) {
-			String postDate = getPostDate(news);
-			LocalDateTime newsPostDate = LocalDateTime.parse(postDate, TIME_FORMATTER);
-			// 오전 6시 크롤링이기 때문에 전날 뉴스는 오전 6시이후로만 가져오도록
-			if (yesterday && newsPostDate.toLocalTime().isBefore(LocalTime.of(6, 0))) {
-				break;
-			}
-
-			saveNews(getTitle(news), getThumbImg(news), newsPostDate);
-		}
-	}
-
-	private void saveNews(String title, String thumbImg, LocalDateTime postDate) {
-		this.newsService.saveNews(NewsSaveRequest.createFootballRequest(title, thumbImg, postDate));
-	}
-
-	private List<WebElement> getNewsList() {
-		WebElement newsListElement = webDriver.findElement(By.className(NEWS_LIST_CLASS));
-		return newsListElement.findElements(By.tagName(LI_TAG));
-	}
-
-	//뉴스 시간가져오기
-	private String getPostDate(WebElement news) {
-		return news.findElement(By.className(TIME_CLASS)).getText();
-	}
-
-	//뉴스 타이틀가져오기
-	private String getTitle(WebElement news) {
-		return news.findElement(By.className(TITLE_CLASS)).findElement(By.tagName(SPAN_TAG)).getText();
-	}
-
-	//썸네일 이미지 가져오기, 없으면 null
-	private String getThumbImg(WebElement news) {
-		try {
-			return news.findElement(By.className(THUMB_CLASS)).findElement(By.tagName(IMG_TAG)).getAttribute(SRC_ATTR);
-		} catch (NoSuchElementException e) {
-			return null;
-		}
-	}
-
-	//페이징 개수 가져오기
-	private int getPaginationCount(LocalDate date) {
-		webDriver.get(URL + DATE_FIELD + EQUALS + date.format(FORMATTER) + PAGE_FIELD + EQUALS + 1);
-		WebElement paginationElement = webDriver.findElement(By.className(PAGE_CLASS));
-		List<WebElement> pageLinks = paginationElement.findElements(By.tagName(A_TAG));
-		return pageLinks.size();
+		crawlForDate(URL, currentDate.minusDays(1), true); // 어제 뉴스 크롤링
+		crawlForDate(URL, currentDate, false); // 오늘 뉴스 크롤링
 	}
 }

--- a/src/main/java/com/playhive/batch/crawler/football/KFootballNewsCrawler.java
+++ b/src/main/java/com/playhive/batch/crawler/football/KFootballNewsCrawler.java
@@ -1,0 +1,27 @@
+package com.playhive.batch.crawler.football;
+
+import java.time.LocalDate;
+
+import org.openqa.selenium.WebDriver;
+import org.springframework.stereotype.Component;
+
+import com.playhive.batch.crawler.Crawler;
+import com.playhive.batch.crawler.FootballBaseballCrawler;
+import com.playhive.batch.news.service.NewsService;
+
+@Component
+public class KFootballNewsCrawler extends FootballBaseballCrawler implements Crawler {
+
+	private static final String URL = "https://sports.news.naver.com/kfootball/news/index?isphoto=N";
+
+	public KFootballNewsCrawler(WebDriver webDriver, NewsService newsService) {
+		super(webDriver, newsService);
+	}
+
+	@Override
+	public void crawl() {
+		LocalDate currentDate = LocalDate.now();
+		crawlForDate(URL, currentDate.minusDays(1), true); // 어제 뉴스 크롤링
+		crawlForDate(URL, currentDate, false); // 오늘 뉴스 크롤링
+	}
+}

--- a/src/main/java/com/playhive/batch/crawler/football/WFootballNewsCrawler.java
+++ b/src/main/java/com/playhive/batch/crawler/football/WFootballNewsCrawler.java
@@ -21,11 +21,11 @@ import com.playhive.batch.news.service.NewsService;
 import lombok.RequiredArgsConstructor;
 
 @Component
-public class FootballNewsCrawler extends FootballBaseballCrawler implements Crawler {
+public class WFootballNewsCrawler extends FootballBaseballCrawler implements Crawler {
 
 	private static final String URL = "https://sports.news.naver.com/wfootball/news/index?isphoto=N";
 
-	public FootballNewsCrawler(WebDriver webDriver, NewsService newsService) {
+	public WFootballNewsCrawler(WebDriver webDriver, NewsService newsService) {
 		super(webDriver, newsService);
 	}
 

--- a/src/main/java/com/playhive/batch/job/NewsCrawlJobConfig.java
+++ b/src/main/java/com/playhive/batch/job/NewsCrawlJobConfig.java
@@ -1,5 +1,7 @@
 package com.playhive.batch.job;
 
+import java.util.List;
+
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
@@ -31,8 +33,7 @@ public class NewsCrawlJobConfig {
 	private static final String NEWS_CRAWL_STEP_NAME = "newsCrawlStep";
 
 	private final WebDriver webDriver;
-	private final NewsService newsService;
-	private final NewsCountService newsCountService;
+	private final List<Crawler> crawlers;
 
 	@Bean
 	public Job newsCrawlJob(JobRepository jobRepository, Step newsCrawlStep) {
@@ -53,8 +54,9 @@ public class NewsCrawlJobConfig {
 	@Bean
 	public Tasklet newsTasklet() {
 		return (contribution, chunkContext) -> {
-			Crawler footballNewsCrawler = new FootballNewsCrawler(webDriver, newsService, newsCountService);
-			footballNewsCrawler.crawl();
+			for (Crawler crawler : crawlers) {
+				crawler.crawl();
+			}
 			webDriver.close();
 			return RepeatStatus.FINISHED;
 		};

--- a/src/main/java/com/playhive/batch/news/dto/NewsSaveRequest.java
+++ b/src/main/java/com/playhive/batch/news/dto/NewsSaveRequest.java
@@ -35,6 +35,24 @@ public class NewsSaveRequest {
 			.build();
 	}
 
+	public static NewsSaveRequest createBaseballRequest(String title, String thumbImg, LocalDateTime postDate) {
+		return NewsSaveRequest.builder()
+			.category(NewsCategory.BASEBALL)
+			.title(title)
+			.thumbImg(thumbImg)
+			.postDate(postDate)
+			.build();
+	}
+
+	public static NewsSaveRequest createEsportsRequest(String title, String thumbImg, LocalDateTime postDate) {
+		return NewsSaveRequest.builder()
+			.category(NewsCategory.ESPORTS)
+			.title(title)
+			.thumbImg(thumbImg)
+			.postDate(postDate)
+			.build();
+	}
+
 	public News toEntity() {
 		return News.builder()
 			.category(category)

--- a/src/main/java/com/playhive/batch/news/service/NewsService.java
+++ b/src/main/java/com/playhive/batch/news/service/NewsService.java
@@ -15,9 +15,11 @@ import lombok.RequiredArgsConstructor;
 public class NewsService {
 
 	private final NewsRepository newsRepository;
+	private final NewsCountService newsCountService;
 
-	public News saveNews(NewsSaveRequest newsSaveRequest) {
-		return newsRepository.save(newsSaveRequest.toEntity());
+	public void saveNews(NewsSaveRequest newsSaveRequest) {
+		News news = newsRepository.save(newsSaveRequest.toEntity());
+		newsCountService.saveNewsCount(news);
 	}
 
 }


### PR DESCRIPTION
## 기능 설명
- 국내야구 크롤링
- E스포츠 롤 크롤링
### 작업 내용
- BaseballCrawler
- EsportsCrawler
## 수정 사항
- 축구와 야구는 페이지 포맷이 동일하여 추상클래스로 묶어줌
## 추가 작업 예정
- 뉴스 관련 배치는 끝난 것으로 보이고
- 경기일정 관련 API를 활용한 배치작업 예정
### 테스트
- [ ] 단위 테스트 확인
- [x] 빌드 테스트 확인
- [x] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 / Swagger 확인
