### PR TITLE
feat: 게임 이벤트, 할인 정보 크롤링 (넥슨, 스팀)

### DIFF
--- a/src/main/java/com/playhive/batch/crawler/game/GameCrawler.java
+++ b/src/main/java/com/playhive/batch/crawler/game/GameCrawler.java
@@ -1,0 +1,5 @@
+package com.playhive.batch.crawler.game;
+
+public interface GameCrawler {
+    void crawl();
+}

--- a/src/main/java/com/playhive/batch/crawler/game/gameDiscount/GameDiscountCrawler.java
+++ b/src/main/java/com/playhive/batch/crawler/game/gameDiscount/GameDiscountCrawler.java
@@ -96,8 +96,9 @@ public class GameDiscountCrawler implements GameCrawler {
 
         // 특가 콘텐츠가 로드될 때까지 대기
         log.info("특가 콘텐츠 로딩 대기 중...");
-        WebElement specialContent = wait.until(ExpectedConditions.visibilityOfElementLocated(
-                By.id(SPECIALS_CONTENT)));
+        WebElement specialContent = wait.until(
+                ExpectedConditions.visibilityOfElementLocated(By.id(SPECIALS_CONTENT))
+        );
 
         try {
             // 페이지 완전히 로드될 때까지 잠시 대기

--- a/src/main/java/com/playhive/batch/crawler/game/gameDiscount/GameDiscountCrawler.java
+++ b/src/main/java/com/playhive/batch/crawler/game/gameDiscount/GameDiscountCrawler.java
@@ -54,8 +54,8 @@ public class GameDiscountCrawler implements GameCrawler {
 
     @Override
     public void crawl() {
-        webDriver = WebDriverConfig.createDriver();
         try {
+            webDriver = WebDriverConfig.createDriver();
             crawlGameDiscount();
         } finally {
             webDriver.quit();

--- a/src/main/java/com/playhive/batch/crawler/game/gameDiscount/GameDiscountCrawler.java
+++ b/src/main/java/com/playhive/batch/crawler/game/gameDiscount/GameDiscountCrawler.java
@@ -1,0 +1,158 @@
+package com.playhive.batch.crawler.game.gameDiscount;
+
+import com.playhive.batch.crawler.game.GameCrawler;
+import com.playhive.batch.game.gameDiscount.dto.GameDiscountSaveRequest;
+import com.playhive.batch.game.gameDiscount.service.GameDiscountService;
+import com.playhive.batch.global.config.WebDriverConfig;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class GameDiscountCrawler implements GameCrawler {
+
+    private static final String URL = "https://store.steampowered.com/?l=koreana";
+
+    private static final String TRIGGER_TAB = "#tab_specials_content_trigger";
+    private static final String JAVASCRIPT_CLICK = "arguments[0].click();";
+    private static final String SPECIALS_CONTENT = "tab_specials_content";
+    private static final String ITEM = ".tab_item";
+
+    // 링크
+    private static final String HREF_ATTR = "href";
+    // 게임명
+    private static final String GAME_NAME = "tab_item_name";
+    // 이미지
+    private static final String GAME_IMAGE = "tab_item_cap_img";
+    private static final String SRC_ATTR = "src";
+    // 가격 정보
+    private static final String DISCOUNT_BLOCK = "discount_block";
+    // 할인율
+    private static final String DISCOUNT_PCT = "discount_pct";
+    // 할인 전 가격
+    private static final String ORIGINAL_PRICE = "discount_original_price";
+    // 할인된 가격
+    private static final String FINAL_PRICE = "discount_final_price";
+
+    private WebDriver webDriver;
+    private final GameDiscountService gameDiscountService;
+
+    public GameDiscountCrawler(GameDiscountService gameDiscountService) {
+        this.gameDiscountService = gameDiscountService;
+    }
+
+    @Override
+    public void crawl() {
+        webDriver = WebDriverConfig.createDriver();
+        try {
+            crawlGameDiscount();
+        } finally {
+            webDriver.quit();
+        }
+    }
+
+    private void crawlGameDiscount() {
+        webDriver.get(URL);
+        // 명시적 대기 설정
+        WebDriverWait wait = new WebDriverWait(webDriver, Duration.ofSeconds(15));
+        clickSpecialsTab(wait);
+        saveGameDiscount(wait);
+    }
+
+    private void saveGameDiscount(WebDriverWait wait) {
+        for (WebElement gameElement : getGameList(wait)) {
+            if (gameElement == null) {
+                break;
+            }
+
+            // 노출 기간
+            LocalDateTime exposureDate = LocalDateTime.of(LocalDate.now().plusDays(1), LocalTime.MIDNIGHT);
+
+            // 가격 정보 요소
+            WebElement discountBlock = gameElement.findElement(By.className(DISCOUNT_BLOCK));
+
+            gameDiscountService.saveGameDiscount(GameDiscountSaveRequest.createRequest(
+                    getThumbImg(gameElement), getTitle(gameElement), getOriginalPrice(discountBlock),
+                    getDiscountPercent(discountBlock), getFinalPrice(discountBlock),
+                    getLink(gameElement), exposureDate));
+        }
+    }
+
+    /**
+     * 할인 게임 목록 가져오기
+     */
+    private List<WebElement> getGameList(WebDriverWait wait) {
+
+        // 특가 콘텐츠가 로드될 때까지 대기
+        log.info("특가 콘텐츠 로딩 대기 중...");
+        WebElement specialContent = wait.until(ExpectedConditions.visibilityOfElementLocated(
+                By.id(SPECIALS_CONTENT)));
+
+        try {
+            // 페이지 완전히 로드될 때까지 잠시 대기
+            Thread.sleep(2000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("Thread sleep 중단됨", e);
+            return null;
+        }
+
+        // 할인 게임 목록 찾기
+        List<WebElement> gameElements = specialContent.findElements(
+                By.cssSelector(ITEM));
+
+        log.info("발견된 게임 수: {}", gameElements.size());
+        return gameElements;
+    }
+
+    /**
+     * 스페셜 탭 클릭
+     */
+    private void clickSpecialsTab(WebDriverWait wait) {
+        // 스페셜 탭 클릭
+        log.info("스페셜 탭 찾는 중...");
+        WebElement specialsTab = wait.until(ExpectedConditions.elementToBeClickable(
+                By.cssSelector(TRIGGER_TAB)));
+
+        log.info("스페셜 탭 클릭 시도...");
+        // 자바스크립트 실행기로 클릭 (더 안정적인 방법)
+        JavascriptExecutor jsExecutor = (JavascriptExecutor) webDriver;
+        jsExecutor.executeScript(JAVASCRIPT_CLICK, specialsTab);
+    }
+
+    private String getFinalPrice(WebElement discountBlock) {
+        return discountBlock.findElement(By.className(FINAL_PRICE)).getText();
+    }
+
+    private String getDiscountPercent(WebElement discountBlock) {
+        return discountBlock.findElement(By.className(DISCOUNT_PCT)).getText();
+    }
+
+    private String getOriginalPrice(WebElement discountBlock) {
+        return discountBlock.findElement(By.className(ORIGINAL_PRICE)).getText();
+    }
+
+    private String getLink(WebElement gameElement) {
+        return gameElement.getAttribute(HREF_ATTR);
+    }
+
+    private String getTitle(WebElement gameElement) {
+        return gameElement.findElement(By.className(GAME_NAME)).getText();
+    }
+
+    private String getThumbImg(WebElement gameElement) {
+        WebElement imgElement = gameElement.findElement(By.className(GAME_IMAGE));
+        return imgElement.getAttribute(SRC_ATTR);
+    }
+}

--- a/src/main/java/com/playhive/batch/crawler/game/gameDiscount/GameDiscountCrawler.java
+++ b/src/main/java/com/playhive/batch/crawler/game/gameDiscount/GameDiscountCrawler.java
@@ -132,7 +132,8 @@ public class GameDiscountCrawler implements GameCrawler {
     }
 
     private String getFinalPrice(WebElement discountBlock) {
-        return discountBlock.findElement(By.className(FINAL_PRICE)).getText();
+        String finalPrice = discountBlock.findElement(By.className(FINAL_PRICE)).getText();
+        return finalPrice.replaceAll("[^0-9]", "");
     }
 
     private String getDiscountPercent(WebElement discountBlock) {
@@ -140,7 +141,8 @@ public class GameDiscountCrawler implements GameCrawler {
     }
 
     private String getOriginalPrice(WebElement discountBlock) {
-        return discountBlock.findElement(By.className(ORIGINAL_PRICE)).getText();
+        String originalPrice = discountBlock.findElement(By.className(ORIGINAL_PRICE)).getText();
+        return originalPrice.replaceAll("[^0-9]", "");
     }
 
     private String getLink(WebElement gameElement) {

--- a/src/main/java/com/playhive/batch/crawler/game/gameEvent/GameEventCrawler.java
+++ b/src/main/java/com/playhive/batch/crawler/game/gameEvent/GameEventCrawler.java
@@ -1,0 +1,104 @@
+package com.playhive.batch.crawler.game.gameEvent;
+
+import com.playhive.batch.crawler.game.GameCrawler;
+import com.playhive.batch.game.gameEvent.dto.GameEventSaveRequest;
+import com.playhive.batch.game.gameEvent.service.GameEventService;
+import com.playhive.batch.global.config.WebDriverConfig;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class GameEventCrawler implements GameCrawler {
+
+    private static final String URL = "https://event.nexon.com/event/ongoinglist.aspx";
+
+    private static final String EVENT_LIST_CLASS = "eventList";
+    private static final String LI_EVENT_ITEM = "eventItem";
+    // 링크
+    private static final String A_TAG = "a";
+    private static final String HREF_ATTR = "href";
+    // 썸네일 이미지
+    private static final String SPAN_EVENT_IMG = "eventImg";
+    private static final String IMG_TAG = "img";
+    private static final String SRC_ATTR = "src";
+    // 이벤트 제목
+    private static final String EVENT_TITLE = "eventTit";
+    // 이벤트 소개
+    private static final String EVENT_DESCRIPTION = "eventCnts";
+    // 이벤트 기간
+    private static final String EVENT_PERIOD = "eventPeriod";
+
+    private final GameEventService gameEventService;
+    private WebDriver webDriver;
+
+    public GameEventCrawler(GameEventService gameEventService) {
+        this.gameEventService = gameEventService;
+    }
+
+    @Override
+    public void crawl() {
+        webDriver = WebDriverConfig.createDriver();
+        crawlGameEvent();
+        webDriver.quit();
+    }
+
+    private void crawlGameEvent() {
+        webDriver.get(URL);
+        try {
+            saveEvent();
+        } catch (Exception e) {
+            log.error("Error occurred while crawling events", e.getMessage());
+        }
+    }
+
+    private void saveEvent() {
+        for (WebElement event : getEventList()) {
+            try {
+                saveGameEvent(getThumbImg(event), getTitle(event), getDescription(event), getPeriod(event),
+                        getLink(event));
+            } catch (Exception e) {
+                log.error("Error while processing event: {}", e.getMessage(), e);
+            }
+        }
+    }
+
+    private void saveGameEvent(String thumbImg, String title, String description, String period, String link) {
+        // 노출 기간
+        LocalDateTime exposureDate = LocalDateTime.of(LocalDate.now().plusDays(1), LocalTime.MIDNIGHT);
+        gameEventService.saveGameEvent(
+                GameEventSaveRequest.createRequest(thumbImg, title, description, period, link, exposureDate));
+    }
+
+    private String getTitle(WebElement event) {
+        return event.findElement(By.className(EVENT_TITLE)).getText();
+    }
+
+    private String getDescription(WebElement event) {
+        return event.findElement(By.className(EVENT_DESCRIPTION)).getText();
+    }
+
+    private String getPeriod(WebElement event) {
+        return event.findElement(By.className(EVENT_PERIOD)).getText();
+    }
+
+    private String getThumbImg(WebElement event) {
+        return event.findElement(By.className(SPAN_EVENT_IMG)).findElement(By.tagName(IMG_TAG)).getAttribute(SRC_ATTR);
+    }
+
+    private String getLink(WebElement event) {
+        return event.findElement(By.tagName(A_TAG)).getAttribute(HREF_ATTR);
+    }
+
+    private List<WebElement> getEventList() {
+        WebElement eventListElement = webDriver.findElement(By.className(EVENT_LIST_CLASS));
+        return eventListElement.findElements(By.className(LI_EVENT_ITEM));
+    }
+}

--- a/src/main/java/com/playhive/batch/crawler/game/gameEvent/GameEventCrawler.java
+++ b/src/main/java/com/playhive/batch/crawler/game/gameEvent/GameEventCrawler.java
@@ -45,9 +45,12 @@ public class GameEventCrawler implements GameCrawler {
 
     @Override
     public void crawl() {
-        webDriver = WebDriverConfig.createDriver();
-        crawlGameEvent();
-        webDriver.quit();
+        try {
+            webDriver = WebDriverConfig.createDriver();
+            crawlGameEvent();
+        } finally {
+            webDriver.quit();
+        }
     }
 
     private void crawlGameEvent() {

--- a/src/main/java/com/playhive/batch/game/gameDiscount/dto/GameDiscountSaveRequest.java
+++ b/src/main/java/com/playhive/batch/game/gameDiscount/dto/GameDiscountSaveRequest.java
@@ -1,0 +1,78 @@
+package com.playhive.batch.game.gameDiscount.dto;
+
+import com.playhive.batch.game.gameDiscount.entity.GameDiscount;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class GameDiscountSaveRequest {
+    /**
+     * 게임 이미지
+     */
+    private String thumbImg;
+    /**
+     * 게임명
+     */
+    private String title;
+    /**
+     * 할인 전 가격
+     */
+    private String originalPrice;
+    /**
+     * 할인율
+     */
+    private String discountPercent;
+    /**
+     * 할인된 가격
+     */
+    private String finalPrice;
+    /**
+     * 연결 링크
+     */
+    private String link;
+    /**
+     * 노출 날짜
+     */
+    private LocalDateTime exposureDate;
+
+    @Builder
+    public GameDiscountSaveRequest(String thumbImg, String title, String originalPrice, String discountPercent,
+                                   String finalPrice, String link, LocalDateTime exposureDate) {
+        this.thumbImg = thumbImg;
+        this.title = title;
+        this.originalPrice = originalPrice;
+        this.discountPercent = discountPercent;
+        this.finalPrice = finalPrice;
+        this.link = link;
+        this.exposureDate = exposureDate;
+    }
+
+    public static GameDiscountSaveRequest createRequest(String thumbImg, String title, String originalPrice,
+                                                        String discountPercent,
+                                                        String finalPrice, String link, LocalDateTime exposureDate) {
+        return GameDiscountSaveRequest.builder()
+                .thumbImg(thumbImg)
+                .title(title)
+                .originalPrice(originalPrice)
+                .discountPercent(discountPercent)
+                .finalPrice(finalPrice)
+                .link(link)
+                .exposureDate(exposureDate)
+                .build();
+    }
+
+    public GameDiscount toEntity() {
+        return GameDiscount.builder()
+                .thumbImg(thumbImg)
+                .title(title)
+                .originalPrice(originalPrice)
+                .discountPercent(discountPercent)
+                .finalPrice(finalPrice)
+                .link(link)
+                .exposureDate(exposureDate)
+                .build();
+    }
+}

--- a/src/main/java/com/playhive/batch/game/gameDiscount/entity/GameDiscount.java
+++ b/src/main/java/com/playhive/batch/game/gameDiscount/entity/GameDiscount.java
@@ -1,0 +1,62 @@
+package com.playhive.batch.game.gameDiscount.entity;
+
+import com.playhive.batch.global.domain.BaseTime;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "p_game_discount")
+public class GameDiscount extends BaseTime {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    /**
+     * 게임 이미지
+     */
+    private String thumbImg;
+    /**
+     * 게임명
+     */
+    private String title;
+    /**
+     * 할인 전 가격
+     */
+    private String originalPrice;
+    /**
+     * 할인율
+     */
+    private String discountPercent;
+    /**
+     * 할인된 가격
+     */
+    private String finalPrice;
+    /**
+     * 연결 링크
+     */
+    private String link;
+    /**
+     * 노출 날짜
+     */
+    private LocalDateTime exposureDate;
+
+    @Builder
+    public GameDiscount(String thumbImg, String title, String originalPrice, String discountPercent,
+                        String finalPrice,
+                        String link, LocalDateTime exposureDate) {
+        this.thumbImg = thumbImg;
+        this.title = title;
+        this.originalPrice = originalPrice;
+        this.discountPercent = discountPercent;
+        this.finalPrice = finalPrice;
+        this.link = link;
+        this.exposureDate = exposureDate;
+    }
+}

--- a/src/main/java/com/playhive/batch/game/gameDiscount/repository/GameDiscountRepository.java
+++ b/src/main/java/com/playhive/batch/game/gameDiscount/repository/GameDiscountRepository.java
@@ -1,0 +1,9 @@
+package com.playhive.batch.game.gameDiscount.repository;
+
+import com.playhive.batch.game.gameDiscount.entity.GameDiscount;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GameDiscountRepository extends JpaRepository<GameDiscount, Long> {
+}

--- a/src/main/java/com/playhive/batch/game/gameDiscount/service/GameDiscountService.java
+++ b/src/main/java/com/playhive/batch/game/gameDiscount/service/GameDiscountService.java
@@ -1,0 +1,19 @@
+package com.playhive.batch.game.gameDiscount.service;
+
+import com.playhive.batch.game.gameDiscount.dto.GameDiscountSaveRequest;
+import com.playhive.batch.game.gameDiscount.repository.GameDiscountRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class GameDiscountService {
+
+    private final GameDiscountRepository gameDiscountRepository;
+
+    public void saveGameDiscount(GameDiscountSaveRequest gameDiscountSaveRequest) {
+        gameDiscountRepository.save(gameDiscountSaveRequest.toEntity());
+    }
+}

--- a/src/main/java/com/playhive/batch/game/gameEvent/dto/GameEventSaveRequest.java
+++ b/src/main/java/com/playhive/batch/game/gameEvent/dto/GameEventSaveRequest.java
@@ -1,0 +1,70 @@
+package com.playhive.batch.game.gameEvent.dto;
+
+import com.playhive.batch.game.gameEvent.entity.GameEvent;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class GameEventSaveRequest {
+    /**
+     * 이벤트 이미지
+     */
+    private String thumbImg;
+    /**
+     * 이벤트 제목
+     */
+    private String title;
+    /**
+     * 이벤트 설명
+     */
+    private String description;
+    /**
+     * 이벤트 기간
+     */
+    private String period;
+    /**
+     * 연결 링크
+     */
+    private String link;
+    /**
+     * 노출 날짜
+     */
+    private LocalDateTime exposureDate;
+
+    @Builder
+    public GameEventSaveRequest(String thumbImg, String title, String description, String period, String link,
+                                LocalDateTime exposureDate) {
+        this.thumbImg = thumbImg;
+        this.title = title;
+        this.description = description;
+        this.period = period;
+        this.link = link;
+        this.exposureDate = exposureDate;
+    }
+
+    public static GameEventSaveRequest createRequest(String thumbImg, String title, String description, String period,
+                                                     String link, LocalDateTime exposureDate) {
+        return GameEventSaveRequest.builder()
+                .thumbImg(thumbImg)
+                .title(title)
+                .description(description)
+                .period(period)
+                .link(link)
+                .exposureDate(exposureDate)
+                .build();
+    }
+
+    public GameEvent toEntity() {
+        return GameEvent.builder()
+                .thumbImg(thumbImg)
+                .title(title)
+                .description(description)
+                .period(period)
+                .link(link)
+                .exposureDate(exposureDate)
+                .build();
+    }
+}

--- a/src/main/java/com/playhive/batch/game/gameEvent/entity/GameEvent.java
+++ b/src/main/java/com/playhive/batch/game/gameEvent/entity/GameEvent.java
@@ -1,0 +1,56 @@
+package com.playhive.batch.game.gameEvent.entity;
+
+import com.playhive.batch.global.domain.BaseTime;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "p_game_event")
+public class GameEvent extends BaseTime {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    /**
+     * 이벤트 이미지
+     */
+    private String thumbImg;
+    /**
+     * 이벤트 제목
+     */
+    private String title;
+    /**
+     * 이벤트 설명
+     */
+    private String description;
+    /**
+     * 이벤트 기간
+     */
+    private String period;
+    /**
+     * 연결 링크
+     */
+    private String link;
+    /**
+     * 노출 날짜
+     */
+    private LocalDateTime exposureDate;
+
+    @Builder
+    public GameEvent(String thumbImg, String title, String description, String period, String link,
+                     LocalDateTime exposureDate) {
+        this.thumbImg = thumbImg;
+        this.title = title;
+        this.description = description;
+        this.period = period;
+        this.link = link;
+        this.exposureDate = exposureDate;
+    }
+}

--- a/src/main/java/com/playhive/batch/game/gameEvent/repository/GameEventRepository.java
+++ b/src/main/java/com/playhive/batch/game/gameEvent/repository/GameEventRepository.java
@@ -1,0 +1,9 @@
+package com.playhive.batch.game.gameEvent.repository;
+
+import com.playhive.batch.game.gameEvent.entity.GameEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GameEventRepository extends JpaRepository<GameEvent, Long> {
+}

--- a/src/main/java/com/playhive/batch/game/gameEvent/service/GameEventService.java
+++ b/src/main/java/com/playhive/batch/game/gameEvent/service/GameEventService.java
@@ -1,0 +1,19 @@
+package com.playhive.batch.game.gameEvent.service;
+
+import com.playhive.batch.game.gameEvent.dto.GameEventSaveRequest;
+import com.playhive.batch.game.gameEvent.repository.GameEventRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class GameEventService {
+
+    private final GameEventRepository gameEventRepository;
+
+    public void saveGameEvent(GameEventSaveRequest gameEventSaveRequest) {
+        gameEventRepository.save(gameEventSaveRequest.toEntity());
+    }
+}

--- a/src/main/java/com/playhive/batch/job/GameCrawlJobConfig.java
+++ b/src/main/java/com/playhive/batch/job/GameCrawlJobConfig.java
@@ -1,0 +1,52 @@
+package com.playhive.batch.job;
+
+import com.playhive.batch.crawler.game.GameCrawler;
+import com.playhive.batch.job.listener.JobLoggerListener;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class GameCrawlJobConfig {
+
+    private static final String GAME_CRAWL_JOB_NAME = "gameCrawlJob";
+    private static final String GAME_CRAWL_STEP_NAME = "gameCrawlStep";
+
+    private final List<GameCrawler> gameCrawlers;
+
+    @Bean
+    public Job gameCrawlJob(JobRepository jobRepository, Step gameCrawlStep) {
+        return new JobBuilder(GAME_CRAWL_JOB_NAME, jobRepository)
+                .listener(new JobLoggerListener())
+                .start(gameCrawlStep)
+                .build();
+    }
+
+    @Bean
+    public Step gameCrawlStep(JobRepository jobRepository, Tasklet gameTasklet,
+                              PlatformTransactionManager transactionManager) {
+        return new StepBuilder(GAME_CRAWL_STEP_NAME, jobRepository)
+                .tasklet(gameTasklet, transactionManager)
+                .build();
+    }
+
+    @Bean
+    public Tasklet gameTasklet() {
+        return (contribution, chunkContext) -> {
+            for (GameCrawler crawler : gameCrawlers) {
+                crawler.crawl();
+            }
+            return RepeatStatus.FINISHED;
+        };
+    }
+}

--- a/src/main/java/com/playhive/batch/schedule/Scheduler.java
+++ b/src/main/java/com/playhive/batch/schedule/Scheduler.java
@@ -1,7 +1,7 @@
 package com.playhive.batch.schedule;
 
 import java.util.Date;
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
@@ -13,59 +13,70 @@ import org.springframework.batch.core.repository.JobRestartException;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import lombok.RequiredArgsConstructor;
-
 @Component
 @RequiredArgsConstructor
 public class Scheduler {
 
-	private final Job newsCrawlJob;
-	private final Job teamCrawlJob;
-	private final Job matchCrawlJob;
-	private final JobLauncher jobLauncher;
+    private final Job newsCrawlJob;
+    private final Job teamCrawlJob;
+    private final Job matchCrawlJob;
+    private final Job gameCrawlJob;
+    private final JobLauncher jobLauncher;
 
-	@Scheduled(cron = "0 0 6 * * *") // 매일 오전 6시 0분 0초에 실행
-	public void newsCrawlJob() throws
-		JobInstanceAlreadyCompleteException,
-		JobExecutionAlreadyRunningException,
-		JobParametersInvalidException,
-		JobRestartException {
+    @Scheduled(cron = "0 0 6 * * *") // 매일 오전 6시 0분 0초에 실행
+    public void newsCrawlJob() throws
+            JobInstanceAlreadyCompleteException,
+            JobExecutionAlreadyRunningException,
+            JobParametersInvalidException,
+            JobRestartException {
 
-		JobParameters jobParameters = new JobParametersBuilder()
-			.addDate("date", new Date())
-			.addLong("time", System.currentTimeMillis())
-			.toJobParameters();
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addDate("date", new Date())
+                .addLong("time", System.currentTimeMillis())
+                .toJobParameters();
 
-		this.jobLauncher.run(newsCrawlJob, jobParameters);
-	}
+        this.jobLauncher.run(newsCrawlJob, jobParameters);
+    }
 
-	@Scheduled(cron = "0 0 5 * * *") // 매일 오전 5시 0분 0초에 실행
-	public void teamCrawlJob() throws
-		JobInstanceAlreadyCompleteException,
-		JobExecutionAlreadyRunningException,
-		JobParametersInvalidException,
-		JobRestartException {
+    @Scheduled(cron = "0 0 5 * * *") // 매일 오전 5시 0분 0초에 실행
+    public void teamCrawlJob() throws
+            JobInstanceAlreadyCompleteException,
+            JobExecutionAlreadyRunningException,
+            JobParametersInvalidException,
+            JobRestartException {
 
-		JobParameters jobParameters = new JobParametersBuilder()
-			.addDate("date", new Date())
-			.addLong("time", System.currentTimeMillis())
-			.toJobParameters();
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addDate("date", new Date())
+                .addLong("time", System.currentTimeMillis())
+                .toJobParameters();
 
-		this.jobLauncher.run(teamCrawlJob, jobParameters);
-	}
+        this.jobLauncher.run(teamCrawlJob, jobParameters);
+    }
 
-	@Scheduled(cron = "0 0 7 * * *") // 매일 오전 7시 0분 0초에 실행
-	public void matchCrawlJob() throws
-		JobInstanceAlreadyCompleteException,
-		JobExecutionAlreadyRunningException,
-		JobParametersInvalidException,
-		JobRestartException {
+    @Scheduled(cron = "0 0 7 * * *") // 매일 오전 7시 0분 0초에 실행
+    public void matchCrawlJob() throws
+            JobInstanceAlreadyCompleteException,
+            JobExecutionAlreadyRunningException,
+            JobParametersInvalidException,
+            JobRestartException {
 
-		JobParameters jobParameters = new JobParametersBuilder()
-			.addDate("date", new Date())
-			.addLong("time", System.currentTimeMillis())
-			.toJobParameters();
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addDate("date", new Date())
+                .addLong("time", System.currentTimeMillis())
+                .toJobParameters();
 
-		this.jobLauncher.run(matchCrawlJob, jobParameters);
-	}
+        this.jobLauncher.run(matchCrawlJob, jobParameters);
+    }
+
+    @Scheduled(cron = "0 0 23 * * *") // 매일 오후 11에 다음날에 노출될 게임 정보 크롤링 실행
+    public void gameEventCrawl() throws JobInstanceAlreadyCompleteException,
+            JobExecutionAlreadyRunningException,
+            JobParametersInvalidException, JobRestartException {
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addDate("date", new Date())
+                .addLong("time", System.currentTimeMillis())
+                .toJobParameters();
+
+        this.jobLauncher.run(gameCrawlJob, jobParameters);
+    }
 }


### PR DESCRIPTION
## 기능 설명
- 넥슨에서는 진행중인 이벤트 정보를 가져왔고, 스팀에서는 게임 할인 정보를 가져왔습니다.
- 두 정보들이 올라온 날짜는 따로 없어서 조회시 어떻게 보여주는게 좋을까 고민하다가, 오후 11시에 크롤링을 하고 exposureDate 를 다음날 00시로 설정하여 저장되도록 설계했습니다.
- 가격들은 따로 가공하지 않을거고 바로 보여지기 때문에 String으로 받아 저장하였습니다. 

### 작업 내용
- 넥슨 진행중인 이벤트 크롤링
- 스팀 할인 정보 크롤링

## 수정 사항


## 추가 작업 예정
- 서비스 레포에서 게임 크롤링 정보 조회 작업 예정

### 테스트
- [ ] 단위 테스트 확인
- [ ] 빌드 테스트 확인
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 / Swagger 확인
