### PR TITLE
feat: 뉴스 배치 2시간으로 수정

### DIFF
--- a/src/main/java/com/playhive/batch/crawler/news/baseball/BaseballNewsCrawler.java
+++ b/src/main/java/com/playhive/batch/crawler/news/baseball/BaseballNewsCrawler.java
@@ -11,6 +11,7 @@ import com.playhive.batch.news.entity.NewsCategory;
 import com.playhive.batch.news.service.NewsService;
 
 @Component
+@Transactional
 public class BaseballNewsCrawler extends FootballBaseballCrawler implements NewsCrawler {
 
 	private static final String URL = "https://m.sports.naver.com/kbaseball/news?sectionId=kbaseball&sort=latest";
@@ -21,8 +22,6 @@ public class BaseballNewsCrawler extends FootballBaseballCrawler implements News
 
 	@Override
 	public void crawl() {
-		LocalDate currentDate = LocalDate.now();
-		crawlForDate(URL, currentDate.minusDays(1), true, NewsCategory.BASEBALL); // 어제 뉴스 크롤링
-		crawlForDate(URL, currentDate, false, NewsCategory.BASEBALL); // 오늘 뉴스 크롤링
+		crawlForDate(URL, LocalDate.now(), NewsCategory.BASEBALL); // 오늘 뉴스 크롤링
 	}
 }

--- a/src/main/java/com/playhive/batch/crawler/news/football/KFootballNewsCrawler.java
+++ b/src/main/java/com/playhive/batch/crawler/news/football/KFootballNewsCrawler.java
@@ -11,6 +11,7 @@ import com.playhive.batch.news.entity.NewsCategory;
 import com.playhive.batch.news.service.NewsService;
 
 @Component
+@Transactional
 public class KFootballNewsCrawler extends FootballBaseballCrawler implements NewsCrawler {
 
 	private static final String URL = "https://m.sports.naver.com/kfootball/news?sectionId=kfootball&sort=latest";
@@ -21,8 +22,6 @@ public class KFootballNewsCrawler extends FootballBaseballCrawler implements New
 
 	@Override
 	public void crawl() {
-		LocalDate currentDate = LocalDate.now();
-		crawlForDate(URL, currentDate.minusDays(1), true, NewsCategory.FOOTBALL); // 어제 뉴스 크롤링
-		crawlForDate(URL, currentDate, false, NewsCategory.FOOTBALL); // 오늘 뉴스 크롤링
+		crawlForDate(URL, LocalDate.now(), NewsCategory.FOOTBALL); // 오늘 뉴스 크롤링
 	}
 }

--- a/src/main/java/com/playhive/batch/crawler/news/football/WFootballNewsCrawler.java
+++ b/src/main/java/com/playhive/batch/crawler/news/football/WFootballNewsCrawler.java
@@ -11,6 +11,7 @@ import com.playhive.batch.news.entity.NewsCategory;
 import com.playhive.batch.news.service.NewsService;
 
 @Component
+@Transactional
 public class WFootballNewsCrawler extends FootballBaseballCrawler implements NewsCrawler {
 
 	private static final String URL = "https://m.sports.naver.com/wfootball/news?sectionId=epl&sort=latest";
@@ -21,8 +22,6 @@ public class WFootballNewsCrawler extends FootballBaseballCrawler implements New
 
 	@Override
 	public void crawl() {
-		LocalDate currentDate = LocalDate.now();
-		crawlForDate(URL, currentDate.minusDays(1), true, NewsCategory.FOOTBALL); // 어제 뉴스 크롤링
-		crawlForDate(URL, currentDate, false, NewsCategory.FOOTBALL); // 오늘 뉴스 크롤링
+		crawlForDate(URL, LocalDate.now(), NewsCategory.FOOTBALL); // 오늘 뉴스 크롤링
 	}
 }

--- a/src/main/java/com/playhive/batch/news/repository/NewsRepository.java
+++ b/src/main/java/com/playhive/batch/news/repository/NewsRepository.java
@@ -1,8 +1,15 @@
 package com.playhive.batch.news.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.playhive.batch.news.entity.News;
+import com.playhive.batch.news.entity.NewsCategory;
 
 public interface NewsRepository extends JpaRepository<News, Long> {
+
+	@Query("SELECT n.source FROM p_news n WHERE n.category = :category ORDER BY n.createDate DESC LIMIT 1")
+	String findRecentPostDate(@Param("category") NewsCategory category);
+
 }

--- a/src/main/java/com/playhive/batch/news/service/NewsCountService.java
+++ b/src/main/java/com/playhive/batch/news/service/NewsCountService.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class NewsCountService {
 
 	private final NewsCountRepository newsCountRepository;

--- a/src/main/java/com/playhive/batch/news/service/NewsService.java
+++ b/src/main/java/com/playhive/batch/news/service/NewsService.java
@@ -1,16 +1,18 @@
 package com.playhive.batch.news.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.playhive.batch.news.dto.NewsSaveRequest;
 import com.playhive.batch.news.entity.News;
+import com.playhive.batch.news.entity.NewsCategory;
 import com.playhive.batch.news.repository.NewsRepository;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class NewsService {
 
 	private final NewsRepository newsRepository;
@@ -19,6 +21,10 @@ public class NewsService {
 	public void saveNews(NewsSaveRequest newsSaveRequest) {
 		News news = newsRepository.save(newsSaveRequest.toEntity());
 		newsCountService.saveNewsCount(news);
+	}
+
+	public String findRecentPostDate(NewsCategory category) {
+		return newsRepository.findRecentPostDate(category);
 	}
 
 }

--- a/src/main/java/com/playhive/batch/schedule/Scheduler.java
+++ b/src/main/java/com/playhive/batch/schedule/Scheduler.java
@@ -25,7 +25,7 @@ public class Scheduler {
 	private final Job gameCrawlJob;
 	private final JobLauncher jobLauncher;
 
-	@Scheduled(cron = "0 0 5 * * *") // 매일 오전 5시 0분 0초에 실행
+	@Scheduled(cron = "0 0 */2 * * *") // 매일 2시간 마다 실행
 	public void newsCrawlJob() throws
 		JobInstanceAlreadyCompleteException,
 		JobExecutionAlreadyRunningException,


### PR DESCRIPTION
## 기능 설명
- 2시간마다 배치로 수정했습니다.
- 트랜잭션을 다 묶어줬습니다.
- 중복 방지를 위해 최신 뉴스출처를 가져와 비교해주도록 했습니다.
- 2시간마다 배치기 때문에 전날 뉴스 크롤링은 제거 햇습니다.
### 작업 내용
- 
## 수정 사항
- 
## 추가 작업 예정
- 
### 테스트
- [ ] 단위 테스트 확인
- [ ] 빌드 테스트 확인
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 / Swagger 확인
