### PR TITLE
refac: 뉴스 생성시 es에 저장

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,10 @@ dependencies {
     implementation group: 'com.mysql', name: 'mysql-connector-j', version: '8.3.0'
 
     implementation group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '4.31.0'
+
+    // ElasticSearch
+    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+    implementation 'jakarta.json:jakarta.json-api:2.1.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/playhive/batch/news/entity/NewsDocument.java
+++ b/src/main/java/com/playhive/batch/news/entity/NewsDocument.java
@@ -1,0 +1,24 @@
+package com.playhive.batch.news.entity;
+
+import jakarta.persistence.Id;
+import lombok.*;
+import org.springframework.data.elasticsearch.annotations.Document;
+
+import java.time.LocalDateTime;
+
+@Document(indexName = "news")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NewsDocument {
+
+    @Id
+    private String id;
+
+    private String title;
+    private String content;
+    private String category;
+    private LocalDateTime postDate;
+}

--- a/src/main/java/com/playhive/batch/news/repository/NewsSearchRepository.java
+++ b/src/main/java/com/playhive/batch/news/repository/NewsSearchRepository.java
@@ -1,0 +1,14 @@
+package com.playhive.batch.news.repository;
+
+import com.playhive.batch.news.entity.NewsDocument;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface NewsSearchRepository extends ElasticsearchRepository<NewsDocument, String> {
+
+    // 기본 쿼리: 제목 또는 내용에 키워드 포함
+    Page<NewsDocument> findByTitleContainingOrContentContaining(
+            String title, String content, Pageable pageable
+    );
+}

--- a/src/main/java/com/playhive/batch/news/repository/NewsSearchRepository.java
+++ b/src/main/java/com/playhive/batch/news/repository/NewsSearchRepository.java
@@ -6,9 +6,5 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
 public interface NewsSearchRepository extends ElasticsearchRepository<NewsDocument, String> {
-
-    // 기본 쿼리: 제목 또는 내용에 키워드 포함
-    Page<NewsDocument> findByTitleContainingOrContentContaining(
-            String title, String content, Pageable pageable
-    );
+    
 }

--- a/src/main/java/com/playhive/batch/news/service/NewsService.java
+++ b/src/main/java/com/playhive/batch/news/service/NewsService.java
@@ -1,5 +1,8 @@
 package com.playhive.batch.news.service;
 
+import com.playhive.batch.news.entity.NewsDocument;
+import com.playhive.batch.news.repository.NewsSearchRepository;
+import jakarta.annotation.PostConstruct;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,6 +13,8 @@ import com.playhive.batch.news.repository.NewsRepository;
 
 import lombok.RequiredArgsConstructor;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -17,10 +22,48 @@ public class NewsService {
 
 	private final NewsRepository newsRepository;
 	private final NewsCountService newsCountService;
+	private final NewsSearchRepository newsSearchRepository;
+
+    @PostConstruct
+    public void setUpES() {
+        System.out.println("================ 초기화 시작 ===================");
+        List<News> allNews = newsRepository.findAll();
+        syncToElastic(allNews);
+        System.out.println("================ 초기화 완료 ===================");
+    }
+
+    public void syncToElastic(List<News> newsList) {
+        int batchSize = 1000;
+
+        for (int i = 0; i < newsList.size(); i += batchSize) {
+            int end = Math.min(i + batchSize, newsList.size());
+            List<NewsDocument> chunk = newsList.subList(i, end).stream()
+                    .map(news -> NewsDocument.builder()
+                            .id(news.getId().toString())
+                            .title(news.getTitle())
+                            .content(news.getContent())
+                            .category(news.getCategory().name())
+                            .postDate(news.getPostDate())
+                            .build())
+                    .toList();
+
+            newsSearchRepository.saveAll(chunk);
+        }
+    }
 
 	public void saveNews(NewsSaveRequest newsSaveRequest) {
 		News news = newsRepository.save(newsSaveRequest.toEntity());
 		newsCountService.saveNewsCount(news);
+
+		NewsDocument doc = NewsDocument.builder()
+				.id(String.valueOf(news.getId()))
+				.title(news.getTitle())
+				.content(news.getContent())
+				.category(news.getCategory().name())
+				.postDate(news.getPostDate())
+				.build();
+
+		newsSearchRepository.save(doc);
 	}
 
 	public String findRecentPostDate(NewsCategory category) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,7 +15,6 @@ spring:
     hikari:
       maximum-pool-size: 20
 
-
   jpa:
     show-sql: false
     properties:
@@ -31,6 +30,9 @@ spring:
       #  validate Entity 와 테이블이 정상 매핑 되었는지 확인
       #  none 기존테이블을 더 이상 건드리지 않음.
     open-in-view: true
+
+  elasticsearch:
+    uris: http://{es-server-ip}:9200
 
 logging:
   level:


### PR DESCRIPTION
## 기능 설명
- 뉴스 작업 시 es 적용
### 작업 내용
- 뉴스 생성할 때 es에 저장합니다.
- 이전에 있던 뉴스들을 es에 저장해야해서 초기화 로직 돌렸는데, 이거 한번하고 삭제해야합니다. => 따라서 팀원들과 논의가 필요합니다.
- 또한 배치서버에서 api서버를 바라봐야 es가 저장되기 때문에 env도 작업해야합니다
## 수정 사항
- postconstruct method 삭제
## 추가 작업 예정
- env도 작업(API 서버 host 명 넣기)
### 테스트
- [ ] 단위 테스트 확인
- [ ] 빌드 테스트 확인
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 / Swagger 확인
